### PR TITLE
Oauth Improvements

### DIFF
--- a/docs/oauth2-oidc.md
+++ b/docs/oauth2-oidc.md
@@ -50,3 +50,11 @@ You can now log in to Okta through React Native clients on iOS, Android, and Web
 **Note:** These steps are only necessary if you are using JHipster v6, or JHipster v7 with a Reactive JHipster backend.
 
 Follow the instructions under "Add Claims to Access Token" in the [JHipster Ionic ReadMe](https://github.com/oktadeveloper/generator-jhipster-ionic/blob/6d1c64082fe8ca53e44656021b3549c5708764af/README.md#add-claims-to-access-token).
+
+### Log Out from the Identity Provider (iOS/Android)
+
+Expo's auth proxy does not currently work with logging out from the identity provider (supported and enabled on Web).  If you want to completely sign out on native apps:
+- Change `useExpoAuthProxy` to `false` in `app-config.js`
+- Configure your redirect URLs for logout in your identity provider
+  - Usually something like `exp://127.0.0.1:19000` and `exp://10.0.0.114:19000`, where `10.0.0.114` is your local IP
+- A popup will appear on browser open, but will say "Expo wants to use identy-provider.com to sign in", but it will really be signing out.

--- a/generators/app/templates/app/config/app-config.js.ejs
+++ b/generators/app/templates/app/config/app-config.js.ejs
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import Constants from 'expo-constants';
 
 // load extra config from the app.json file
@@ -9,8 +10,8 @@ export default {
   <%_ if (context.authenticationType === 'oauth2') { _%>
   // leave blank if using Keycloak
   nativeClientId: '',
-  // use expo auth proxy with login, disable to log completely out of oauth provider
-  useExpoAuthProxy: true,
+  // use expo auth proxy with login, disable to enable logout completely from oauth provider
+  useExpoAuthProxy: Platform.select({ web: false, default: true }),
   <%_ } _%>
   // use fixtures instead of real API requests
   useFixtures: false,

--- a/generators/app/templates/app/config/app-config.js.ejs
+++ b/generators/app/templates/app/config/app-config.js.ejs
@@ -9,6 +9,8 @@ export default {
   <%_ if (context.authenticationType === 'oauth2') { _%>
   // leave blank if using Keycloak
   nativeClientId: '',
+  // use expo auth proxy with login, disable to log completely out of oauth provider
+  useExpoAuthProxy: true,
   <%_ } _%>
   // use fixtures instead of real API requests
   useFixtures: false,

--- a/generators/app/templates/app/config/redux-persist.js.ejs
+++ b/generators/app/templates/app/config/redux-persist.js.ejs
@@ -8,7 +8,7 @@ const REDUX_PERSIST = {
   storeConfig: {
     key: 'primary',
     storage: AsyncStorage,
-    blacklist: ['appState'], // reducer keys that you do NOT want stored to persistence here
+    blacklist: ['appState', 'authInfo'], // reducer keys that you do NOT want stored to persistence here
     // whitelist: [], Optionally, just specify the keys you DO want stored to
     // persistence. An empty array means 'don't store any reducers' -> infinitered/ignite#409
     transforms: [immutablePersistenceTransform]

--- a/generators/app/templates/app/modules/login/login.sagas.js.ejs
+++ b/generators/app/templates/app/modules/login/login.sagas.js.ejs
@@ -37,6 +37,9 @@ export function * login (api) {
   } catch (e) {
     let errorMessage = e.type === 'Dismiss' ? 'Login Modal dismissed' : 'Login failed, please try again';
     yield put(LoginActions.loginFailure(errorMessage));
+    if (AppConfig.debugMode) {
+      console.error(e);
+    }
   }
 }
 

--- a/generators/app/templates/app/modules/login/login.utils.ts.ejs
+++ b/generators/app/templates/app/modules/login/login.utils.ts.ejs
@@ -68,10 +68,8 @@ export async function getDiscovery(issuer: string): Promise<DiscoveryDocument> {
 }
 
 export async function doOauthPkceFlow(clientId: string, issuer: string): Promise<AuthSession.TokenResponse> {
-  // whether or not to use the expo proxy
-  const useProxy = Platform.select({ web: false, default: AppConfig.useExpoAuthProxy });
   // set up redirect uri
-  const redirectUri = makeRedirectUri({ useProxy });
+  const redirectUri = makeRedirectUri({ useProxy: AppConfig.useExpoAuthProxy });
   // fetch oauth issuer information from discovery endpoint
   const discovery = await getDiscovery(issuer);
   // set up the IDP url, prepare codeVerifier and state
@@ -86,13 +84,11 @@ export async function doOauthPkceFlow(clientId: string, issuer: string): Promise
 
 export async function logoutFromIdp(clientId: string, issuer: string, idToken: string) {
   // logging out of IDP is not supported by the expo auth proxy
-  if (Platform.OS === 'web' || !AppConfig.useExpoAuthProxy) {
+  if (!AppConfig.useExpoAuthProxy) {
     const discovery = await getDiscovery(issuer);
     const { endSessionEndpoint } = discovery;
-    // whether or not to use the expo proxy
-    const useProxy = Platform.select({ web: false, default: AppConfig.useExpoAuthProxy });
     // set up redirect uri
-    const redirectUri = makeRedirectUri({ useProxy });
+    const redirectUri = makeRedirectUri({ useProxy: AppConfig.useExpoAuthProxy });
     await WebBrowser.openAuthSessionAsync(`${endSessionEndpoint}?id_token_hint=${idToken}&client_id=${clientId}&post_logout_redirect_uri=${redirectUri}`, redirectUri);
   }
 }

--- a/generators/app/templates/app/modules/login/login.utils.ts.ejs
+++ b/generators/app/templates/app/modules/login/login.utils.ts.ejs
@@ -5,6 +5,8 @@ import { buildQueryString } from 'expo-auth-session/src/QueryParams';
 import { Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
+import AppConfig from '../../config/app-config';
+
 WebBrowser.maybeCompleteAuthSession();
 
 interface AuthParams {
@@ -67,7 +69,7 @@ export async function getDiscovery(issuer: string): Promise<DiscoveryDocument> {
 
 export async function doOauthPkceFlow(clientId: string, issuer: string): Promise<AuthSession.TokenResponse> {
   // whether or not to use the expo proxy
-  const useProxy = Platform.select({ web: false, default: true });
+  const useProxy = Platform.select({ web: false, default: AppConfig.useExpoAuthProxy });
   // set up redirect uri
   const redirectUri = makeRedirectUri({ useProxy });
   // fetch oauth issuer information from discovery endpoint
@@ -83,13 +85,14 @@ export async function doOauthPkceFlow(clientId: string, issuer: string): Promise
 }
 
 export async function logoutFromIdp(clientId: string, issuer: string, idToken: string) {
-  if (Platform.OS === 'web') {
+  // logging out of IDP is not supported by the expo auth proxy
+  if (Platform.OS === 'web' || !AppConfig.useExpoAuthProxy) {
     const discovery = await getDiscovery(issuer);
     const { endSessionEndpoint } = discovery;
     // whether or not to use the expo proxy
-    const useProxy = Platform.select({ web: false, default: true });
+    const useProxy = Platform.select({ web: false, default: AppConfig.useExpoAuthProxy });
     // set up redirect uri
     const redirectUri = makeRedirectUri({ useProxy });
-    window.location.href = `${endSessionEndpoint}?id_token_hint=${idToken}&client_id=${clientId}&post_logout_redirect_uri=${redirectUri}`;
+    await WebBrowser.openAuthSessionAsync(`${endSessionEndpoint}?id_token_hint=${idToken}&client_id=${clientId}&post_logout_redirect_uri=${redirectUri}`, redirectUri);
   }
 }

--- a/generators/app/templates/app/modules/login/login.utils.ts.ejs
+++ b/generators/app/templates/app/modules/login/login.utils.ts.ejs
@@ -2,7 +2,6 @@ import { DiscoveryDocument, makeRedirectUri } from 'expo-auth-session';
 import * as AuthSession from 'expo-auth-session';
 import { generateHexStringAsync, buildCodeAsync } from 'expo-auth-session/src/PKCE';
 import { buildQueryString } from 'expo-auth-session/src/QueryParams';
-import { Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 import AppConfig from '../../config/app-config';

--- a/generators/app/templates/app/modules/login/login.utils.ts.ejs
+++ b/generators/app/templates/app/modules/login/login.utils.ts.ejs
@@ -86,8 +86,10 @@ export async function logoutFromIdp(clientId: string, issuer: string, idToken: s
   if (!AppConfig.useExpoAuthProxy) {
     const discovery = await getDiscovery(issuer);
     const { endSessionEndpoint } = discovery;
-    // set up redirect uri
-    const redirectUri = makeRedirectUri({ useProxy: AppConfig.useExpoAuthProxy });
-    await WebBrowser.openAuthSessionAsync(`${endSessionEndpoint}?id_token_hint=${idToken}&client_id=${clientId}&post_logout_redirect_uri=${redirectUri}`, redirectUri);
+    if (endSessionEndpoint) {
+      // set up redirect uri
+      const redirectUri = makeRedirectUri({ useProxy: AppConfig.useExpoAuthProxy });
+      await WebBrowser.openAuthSessionAsync(`${endSessionEndpoint}?id_token_hint=${idToken}&client_id=${clientId}&post_logout_redirect_uri=${redirectUri}`, redirectUri);
+    }
   }
 }

--- a/generators/app/templates/app/shared/sagas/auth-info.saga.js.ejs
+++ b/generators/app/templates/app/shared/sagas/auth-info.saga.js.ejs
@@ -5,6 +5,9 @@ import AuthInfoActions from '../reducers/auth-info.reducer';
 export function* getAuthInfo(api) {
   const authInfo = yield call(api.getOauthInfo);
   if (authInfo.ok) {
+    if (authInfo.data.issuer && authInfo.data.issuer.endsWith('/')) {
+      authInfo.data.issuer = authInfo.data.issuer.substring(0, authInfo.data.issuer.length - 1);
+    }
     yield put(AuthInfoActions.authInfoSuccess(authInfo.data));
   } else {
     let errorMessage = authInfo.data && authInfo.data.detail ? authInfo.data.detail : 'Failed to reach backend API';

--- a/generators/app/templates/test/spec/modules/login/login.sagas.spec.js.ejs
+++ b/generators/app/templates/test/spec/modules/login/login.sagas.spec.js.ejs
@@ -47,7 +47,6 @@ test('login success path', () => {
 })
 test('login failure path', () => {
   <%_ if (context.authenticationType === 'oauth2') { _%>
-  const response = FixtureAPI.getOauthInfo()
   const step = stepper(login(FixtureAPI))
 
   expect(step()).toEqual(select(selectAuthInfo));


### PR DESCRIPTION
- Fix Auth0 by stripping last `/` from auth-info issuer
- Log error on login fail to help debugging reason (only in DEV)
- Always fetch auth-info endpoint once per load (don't save to localstorage forever)
- Move Expo auth proxy usage to a config variable
  - If you want to completely log out of your identity provider, set this to false and update your redirect URLs to include your local IPs.  
  - There is also a confusing UX here where a popup will say "Sign in" but you are really signing out, so disabled by default for now.
  - New docs for this