### PR TITLE
Remove unnecessary '.expo-shared' folder

### DIFF
--- a/lib/generate-react-native-app.js
+++ b/lib/generate-react-native-app.js
@@ -21,7 +21,7 @@ function generateReactNativeApp() {
     });
 
     // collapse generated RN folder into parent folder
-    const rnFiles = ['.expo-shared', '.gitignore', 'app.json', 'babel.config.js', 'package.json', 'tsconfig.json'];
+    const rnFiles = ['.gitignore', 'app.json', 'babel.config.js', 'package.json', 'tsconfig.json'];
     rnFiles.forEach(file => {
       this.fs.move(`${process.cwd()}/${name}/${file}`, `${process.cwd()}/${file}`, { overwrite: true });
     });


### PR DESCRIPTION
Hi,
".expo-shared" folder is no longer located on the [expo-template-blank-typescript](https://www.npmjs.com/package/expo-template-blank-typescript). 