### PR TITLE
drop expo install --check

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -35,7 +35,3 @@ jobs:
         run: npm ci
       - name: lint and test
         run: npm run test
-      - name: check-dependencies
-        run: |
-          cd generators/react-native/resources/expo
-          npm run check-dependencies

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,23 +13,8 @@ concurrency:
   # Cancel intermediate pull request builds
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  check-dependencies:
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.ref_type, '[tag]')"
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: check-dependencies
-        run: |
-          cd generators/react-native/resources/expo
-          npm run check-dependencies
-
   build-matrix:
     runs-on: ubuntu-latest
-    needs: [check-dependencies]
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:


### PR DESCRIPTION
`drop expo install --check` used to just check compatibility with current expo version.
Now it checks latest expo version too.

It's not working as expected.